### PR TITLE
Cirrus: Disable forcetypeassert/maintidx/varnamelen linters

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
         GOLANGCI_ARGS: "--new-from-rev=HEAD~"
     - name: Go Lint $GOOS Mandatory
       env:
-        GOLANGCI_ARGS: "--disable=cyclop,errcheck,errorlint,forbidigo,funlen,gci,gocognit,gocritic,godot,godox,goerr113,gofmt,gofumpt,goimports,golint,gosimple,ineffassign,lll,maligned,nakedret,nestif,nlreturn,nolintlint,paralleltest,scopelint,staticcheck,stylecheck,thelper,unconvert,unparam,unused,whitespace,wrapcheck,wsl"
+        GOLANGCI_ARGS: "--disable=cyclop,errcheck,errorlint,forbidigo,forcetypeassert,funlen,gci,gocognit,gocritic,godot,godox,goerr113,gofmt,gofumpt,goimports,golint,gosimple,ineffassign,lll,maintidx,maligned,nakedret,nestif,nlreturn,nolintlint,paralleltest,scopelint,staticcheck,stylecheck,thelper,unconvert,unparam,unused,varnamelen,whitespace,wrapcheck,wsl"
     - name: Go Lint $GOOS
       env:
         GOLANGCI_ARGS: ""


### PR DESCRIPTION
They raise warnings about upstream Google code that we don't want to deviate from.