### PR TITLE
Add more name and EKU options

### DIFF
--- a/aiaparent.go
+++ b/aiaparent.go
@@ -34,7 +34,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/big"
-	//"net"
+	"net"
 	"os"
 	//"strings"
 	"time"
@@ -156,6 +156,16 @@ func getAIAParent() (x509.Certificate, any) {
 		log.Fatalf("Failed to generate serial number: %v", err)
 	}
 
+	_, ipv4NetAll, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		log.Fatalf("Failed to parse IPv4 constraint: %v", err)
+	}
+
+	_, ipv6NetAll, err := net.ParseCIDR("::/0")
+	if err != nil {
+		log.Fatalf("Failed to parse IPv6 constraint: %v", err)
+	}
+
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
@@ -173,6 +183,9 @@ func getAIAParent() (x509.Certificate, any) {
 
 		PermittedDNSDomainsCritical: true,
 		PermittedDNSDomains:         []string{*host},
+		ExcludedIPRanges:            []*net.IPNet{ipv4NetAll, ipv6NetAll},
+		PermittedEmailAddresses:     []string{*host},
+		PermittedURIDomains:         []string{*host},
 	}
 
 	pubBytes, err := x509.MarshalPKIXPublicKey(publicKey(priv))

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ var (
 	//isCA       = flag.Bool("ca", false, "whether this cert should be its own Certificate Authority")
 	//rsaBits    = flag.Int("rsa-bits", 2048, "Size of RSA key to generate. Ignored if --ecdsa-curve is set")
 	//ecdsaCurve = flag.String("ecdsa-curve", "", "ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521")
-	ecdsaCurve = flag.String("ecdsa-curve", "P256", "ECDSA curve to use to generate a key. Valid values are P224, P256 (default), P384, P521")
+	ecdsaCurve = flag.String("ecdsa-curve", "P256", "ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521")
 	ed25519Key = flag.Bool("ed25519", false, "Generate an Ed25519 key")
 	parentKey  = flag.String("parent-key", "", "(Optional) Path to existing CA private key to sign end-entity cert with")
 	parentChain = flag.String("parent-chain", "", "(Optional) Path to existing CA cert chain to sign end-entity cert with")

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ import (
 var (
 	//host       = flag.String("host", "", "Comma-separated hostnames and IPs to generate a certificate for")
 	host       = flag.String("host", "", "Comma-separated hostnames to generate a certificate for (only use one unless -parent-chain or -grandparent-chain is set)")
+	email      = flag.Bool("email", false, "Generate a certificate for an email address instead of a DNS name")
+	uri        = flag.Bool("uri", false, "Generate a certificate for a URI instead of a DNS name")
 	validFrom  = flag.String("start-date", "", "Creation date formatted as Jan 1 15:04:05 2011")
 	validFor   = flag.Duration("duration", 365*24*time.Hour, "Duration that certificate is valid for")
 	//isCA       = flag.Bool("ca", false, "whether this cert should be its own Certificate Authority")

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"log"
 	"math/big"
 	//"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -161,11 +162,21 @@ func main() {
 	//	if ip := net.ParseIP(h); ip != nil {
 	//		template.IPAddresses = append(template.IPAddresses, ip)
 	//	} else {
+		if *email {
+			template.EmailAddresses = append(template.EmailAddresses, h)
+		} else if *uri {
+			u, err := url.Parse(h)
+			if err != nil {
+				log.Fatalf("Failed to parse URL: %v", err)
+			}
+			template.URIs = append(template.URIs, u)
+		} else {
 			template.DNSNames = append(template.DNSNames, h)
+		}
 	//	}
 	}
 
-	template.Subject.CommonName = template.DNSNames[0]
+	template.Subject.CommonName = hosts[0]
 
 	//if *isCA {
 	//	template.IsCA = true

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ var (
 	host       = flag.String("host", "", "Comma-separated hostnames to generate a certificate for (only use one unless -parent-chain or -grandparent-chain is set)")
 	email      = flag.Bool("email", false, "Generate a certificate for an email address instead of a DNS name")
 	uri        = flag.Bool("uri", false, "Generate a certificate for a URI instead of a DNS name")
+	client     = flag.Bool("client", false, "Generate a certificate for a TLS client instead of a TLS server (EKU)")
+	code       = flag.Bool("code", false, "Generate a certificate for code signing instead of a TLS server (EKU)")
+	smime      = flag.Bool("smime", false, "Generate a certificate for S/MIME instead of a TLS server (EKU)")
 	validFrom  = flag.String("start-date", "", "Creation date formatted as Jan 1 15:04:05 2011")
 	validFor   = flag.Duration("duration", 365*24*time.Hour, "Duration that certificate is valid for")
 	//isCA       = flag.Bool("ca", false, "whether this cert should be its own Certificate Authority")
@@ -153,7 +156,7 @@ func main() {
 		NotAfter:  notAfterFloored,
 
 		KeyUsage:              keyUsage,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		//ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
 
@@ -177,6 +180,16 @@ func main() {
 	}
 
 	template.Subject.CommonName = hosts[0]
+
+	if *client {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	} else if *code {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageCodeSigning)
+	} else if *smime {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageEmailProtection)
+	} else {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	}
 
 	//if *isCA {
 	//	template.IsCA = true

--- a/parent.go
+++ b/parent.go
@@ -191,10 +191,26 @@ func getParent() (x509.Certificate, any) {
 	//		template.IPAddresses = append(template.IPAddresses, ip)
 	//	} else {
 	//		template.DNSNames = append(template.DNSNames, h)
-	template.PermittedDNSDomains = append(template.PermittedDNSDomains, h)
+	if *email {
 	template.PermittedEmailAddresses = append(template.PermittedEmailAddresses, h)
+	} else if *uri {
 	template.PermittedURIDomains = append(template.PermittedURIDomains, h)
+	} else {
+	template.PermittedDNSDomains = append(template.PermittedDNSDomains, h)
+	}
 	//	}
+	}
+
+	if len(template.PermittedDNSDomains) == 0 {
+		template.ExcludedDNSDomains = append(template.ExcludedDNSDomains, ".")
+	}
+
+	if len(template.PermittedEmailAddresses) == 0 {
+		template.ExcludedEmailAddresses = append(template.ExcludedEmailAddresses, ".")
+	}
+
+	if len(template.PermittedURIDomains) == 0 {
+		template.ExcludedURIDomains = append(template.ExcludedURIDomains, ".")
 	}
 
 	//if *isCA {

--- a/parent.go
+++ b/parent.go
@@ -33,7 +33,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/big"
-	//"net"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -156,6 +156,16 @@ func getParent() (x509.Certificate, any) {
 		log.Fatalf("Failed to generate serial number: %v", err)
 	}
 
+	_, ipv4NetAll, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		log.Fatalf("Failed to parse IPv4 constraint: %v", err)
+	}
+
+	_, ipv6NetAll, err := net.ParseCIDR("::/0")
+	if err != nil {
+		log.Fatalf("Failed to parse IPv6 constraint: %v", err)
+	}
+
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
@@ -172,6 +182,7 @@ func getParent() (x509.Certificate, any) {
 		BasicConstraintsValid: true,
 
 		PermittedDNSDomainsCritical: true,
+		ExcludedIPRanges:            []*net.IPNet{ipv4NetAll, ipv6NetAll},
 	}
 
 	hosts := strings.Split(*host, ",")
@@ -181,6 +192,8 @@ func getParent() (x509.Certificate, any) {
 	//	} else {
 	//		template.DNSNames = append(template.DNSNames, h)
 	template.PermittedDNSDomains = append(template.PermittedDNSDomains, h)
+	template.PermittedEmailAddresses = append(template.PermittedEmailAddresses, h)
+	template.PermittedURIDomains = append(template.PermittedURIDomains, h)
 	//	}
 	}
 

--- a/parent.go
+++ b/parent.go
@@ -178,7 +178,7 @@ func getParent() (x509.Certificate, any) {
 
 		IsCA:                  true,
 		KeyUsage:              keyUsage,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		//ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 
 		PermittedDNSDomainsCritical: true,
@@ -211,6 +211,16 @@ func getParent() (x509.Certificate, any) {
 
 	if len(template.PermittedURIDomains) == 0 {
 		template.ExcludedURIDomains = append(template.ExcludedURIDomains, ".")
+	}
+
+	if *client {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	} else if *code {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageCodeSigning)
+	} else if *smime {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageEmailProtection)
+	} else {
+		template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
 	}
 
 	//if *isCA {


### PR DESCRIPTION
This PR adds support for:

* Email and URI SAN.
* Email and URI name constraints.
* TLS client, code signing, and S/MIME EKU.

Encaya, ncp11, and certinject impose their own name/SAN constraints, so this functionality won't actually do anything on its own; it's just for future expansion.